### PR TITLE
fix: increased usec precision from 3 to 6

### DIFF
--- a/lib/ecto_anon/functions/anonymized_date.ex
+++ b/lib/ecto_anon/functions/anonymized_date.ex
@@ -19,10 +19,10 @@ defmodule EctoAnon.Functions.AnonymizedDate do
     do: DateTime.new!(Date.new!(value.year, 01, 01), ~T[00:00:00])
 
   defp do_run(:utc_datetime_usec, value, _opts),
-    do: DateTime.new!(Date.new!(value.year, 01, 01), ~T[00:00:00.000])
+    do: DateTime.new!(Date.new!(value.year, 01, 01), ~T[00:00:00.000000])
 
   defp do_run(:naive_datetime, value, _opts), do: NaiveDateTime.new!(value.year, 1, 1, 0, 0, 0)
 
   defp do_run(:naive_datetime_usec, value, _opts),
-    do: NaiveDateTime.new!(value.year, 1, 1, 0, 0, 0, {0, 3})
+    do: NaiveDateTime.new!(value.year, 1, 1, 0, 0, 0, {0, 6})
 end

--- a/lib/ecto_anon/functions/default.ex
+++ b/lib/ecto_anon/functions/default.ex
@@ -11,11 +11,11 @@ defmodule EctoAnon.Functions.Default do
   @default_decimal Decimal.new("0.0")
   @default_date ~D[1970-01-01]
   @default_datetime ~U[1970-01-01 00:00:00Z]
-  @default_datetime_usec ~U[1970-01-01 00:00:00.000Z]
+  @default_datetime_usec ~U[1970-01-01 00:00:00.000000Z]
   @default_naive_datetime ~N[1970-01-01 00:00:00]
-  @default_naive_datetime_usec ~N[1970-01-01 00:00:00.000]
-  @default_time ~T[00:00:00.000]
-  @default_time_usec ~T[00:00:00.000]
+  @default_naive_datetime_usec ~N[1970-01-01 00:00:00.000000]
+  @default_time ~T[00:00:00]
+  @default_time_usec ~T[00:00:00.000000]
 
   @doc """
   Apply default anonymizing function based on field type.

--- a/test/ecto_anon/functions/anonymized_date_test.exs
+++ b/test/ecto_anon/functions/anonymized_date_test.exs
@@ -8,11 +8,11 @@ defmodule EctoAnon.Functions.AnonymizedDateTest do
 
       assert AnonymizedDate.run(:date, date, []) == ~D[1970-01-01]
       assert AnonymizedDate.run(:utc_datetime, date, []) == ~U[1970-01-01 00:00:00Z]
-      assert AnonymizedDate.run(:utc_datetime_usec, date, []) == ~U[1970-01-01 00:00:00.000Z]
+      assert AnonymizedDate.run(:utc_datetime_usec, date, []) == ~U[1970-01-01 00:00:00.000000Z]
       assert AnonymizedDate.run(:naive_datetime, date, []) == ~N[1970-01-01 00:00:00]
 
       assert AnonymizedDate.run(:naive_datetime_usec, date, []) ==
-               ~N[1970-01-01 00:00:00.000]
+               ~N[1970-01-01 00:00:00.000000]
     end
 
     test "when opts is [:only_year] it returns the date at the beginning of the date's year" do
@@ -22,12 +22,12 @@ defmodule EctoAnon.Functions.AnonymizedDateTest do
       assert AnonymizedDate.run(:utc_datetime, date, [:only_year]) == ~U[2019-01-01 00:00:00Z]
 
       assert AnonymizedDate.run(:utc_datetime_usec, date, [:only_year]) ==
-               ~U[2019-01-01 00:00:00.000Z]
+               ~U[2019-01-01 00:00:00.000000Z]
 
       assert AnonymizedDate.run(:naive_datetime, date, [:only_year]) == ~N[2019-01-01 00:00:00]
 
       assert AnonymizedDate.run(:naive_datetime_usec, date, [:only_year]) ==
-               ~N[2019-01-01 00:00:00.000]
+               ~N[2019-01-01 00:00:00.000000]
     end
   end
 end

--- a/test/ecto_anon/functions/default_test.exs
+++ b/test/ecto_anon/functions/default_test.exs
@@ -9,11 +9,11 @@ defmodule EctoAnon.Functions.DefaultTest do
     decimal: Decimal.new("0.0"),
     date: ~D[1970-01-01],
     utc_datetime: ~U[1970-01-01 00:00:00Z],
-    utc_datetime_usec: ~U[1970-01-01 00:00:00.000Z],
+    utc_datetime_usec: ~U[1970-01-01 00:00:00.000000Z],
     naive_datetime: ~N[1970-01-01 00:00:00],
-    naive_datetime_usec: ~N[1970-01-01 00:00:00.000],
-    time: ~T[00:00:00.000],
-    time_usec: ~T[00:00:00.000]
+    naive_datetime_usec: ~N[1970-01-01 00:00:00.000000],
+    time: ~T[00:00:00],
+    time_usec: ~T[00:00:00.000000]
   ]
 
   @same_value_types [:boolean, :id, :binary_id, :binary]


### PR DESCRIPTION
Should be 6 to match Ecto requirements
Without this you get this error: 

`** (ArgumentError) :utc_datetime_usec expects microsecond precision, got: ~U[1970-01-01 00:00:00.000Z]`

---

Follows [this PR](https://github.com/WTTJ/ecto_anon/pull/13/files)